### PR TITLE
Gate Eruption behind the Fire_ChargeMelee augment.

### DIFF
--- a/Assets/Scripts/Weapon Implementations/FireWeapon.cs
+++ b/Assets/Scripts/Weapon Implementations/FireWeapon.cs
@@ -27,7 +27,7 @@ public class FireWeapon : MonoBehaviour, IElementalWeapon
             chargeDuration = 0;
             return;
         }
-        if (upgrades.Contains(UpgradeType.Fire_ChargeMelee) || true)
+        if (upgrades.Contains(UpgradeType.Fire_ChargeMelee))
         {
             isCharging = true;
             chargeDuration = 0;


### PR DESCRIPTION
Remove the test bypass so charged fire melee is only available after earning the augment from the shop.