### PR TITLE
Fix playthrough console spam from stale scene references.

### DIFF
--- a/Assets/Aaron/Prefabs/CoreSystems.prefab
+++ b/Assets/Aaron/Prefabs/CoreSystems.prefab
@@ -193,15 +193,13 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9044212862459902059}
-  - component: {fileID: 6956448689961842281}
-  - component: {fileID: 6037943935531274313}
   m_Layer: 0
   m_Name: PLACEHOLDER PLAYER
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &9044212862459902059
 Transform:
   m_ObjectHideFlags: 0
@@ -217,64 +215,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 5190892895785977401}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &6956448689961842281
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3925378626850400808}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6bf1621831e28fe408239db60c7226e3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  playerDirectionReference: {fileID: 0}
-  attackRadius: 5
-  dashFactor: 0.2
-  projectileSpeed: 5
-  flickThreshold: 50
-  swordCatchRadius: 1
-  playerDamageFX: {fileID: 0}
-  swordThrowCooldown: 0.5
-  dashSpeed: 10
-  dashDuration: 0.2
-  dashCooldown: 1
-  enemyPhysicsLayer: Enemies
-  speed: 3
-  sword: {fileID: 0}
-  gear: {fileID: 0}
-  elementWeaponDict:
-    _serializedList: []
-  recallParticles: {fileID: 0}
-  recallTime: 1
---- !u!50 &6037943935531274313
-Rigidbody2D:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3925378626850400808}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!1 &4036743303751491451
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main/CombatHUD.unity
+++ b/Assets/Scenes/Main/CombatHUD.unity
@@ -964,7 +964,6 @@ GameObject:
   - component: {fileID: 750143301}
   - component: {fileID: 750143302}
   - component: {fileID: 750143303}
-  - component: {fileID: 750143304}
   m_Layer: 5
   m_Name: EnemyBlipTemplate
   m_TagString: Untagged
@@ -1029,21 +1028,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &750143304
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 750143300}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee584a1223, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
-  m_EffectDistance: {x: 2, y: -2}
-  m_UseGraphicAlpha: 1
 --- !u!1 &750143310
 GameObject:
   m_ObjectHideFlags: 0
@@ -1055,7 +1039,6 @@ GameObject:
   - component: {fileID: 750143311}
   - component: {fileID: 750143312}
   - component: {fileID: 750143313}
-  - component: {fileID: 750143314}
   m_Layer: 5
   m_Name: PlayerBlip
   m_TagString: Untagged
@@ -1120,21 +1103,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &750143314
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 750143310}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee584a1223, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 1}
-  m_EffectDistance: {x: 2, y: -2}
-  m_UseGraphicAlpha: 1
 --- !u!1 &915173291
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -199,7 +199,10 @@ public class PlayerController : PlayerGameplayPawn
             recallSwordCoroutine = null;
         }
 
-        recallParticles?.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+        if (recallParticles != null)
+        {
+            recallParticles.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+        }
         AudioSystem.StopLoop(recallSoundLoop);
 
         SwordProjectile.Instance.StopFlight();
@@ -259,7 +262,10 @@ public class PlayerController : PlayerGameplayPawn
 
     void CancelRecallChannel()
     {
-        recallParticles?.Stop();
+        if (recallParticles != null)
+        {
+            recallParticles.Stop();
+        }
 
         if (recallSwordCoroutine != null)
         {


### PR DESCRIPTION
Remove broken UGUI Shadow components and the legacy placeholder PlayerController so minimap blip pooling and recall cleanup no longer flood the console with errors.