### PR TITLE
Fix boot loading screen flash and add defeat skip delay.

### DIFF
--- a/Assets/Aaron/Editor/DefeatOverlaySetup.cs
+++ b/Assets/Aaron/Editor/DefeatOverlaySetup.cs
@@ -174,7 +174,7 @@ public static class DefeatOverlaySetup
         var serialized = new SerializedObject(visibility);
         serialized.FindProperty("visibilityChannel").objectReferenceValue = channel;
         serialized.FindProperty("target").objectReferenceValue = target;
-        serialized.FindProperty("initiallyVisible").boolValue = true;
+        serialized.FindProperty("initiallyVisible").boolValue = false;
         serialized.ApplyModifiedPropertiesWithoutUndo();
     }
 

--- a/Assets/Aaron/Scripts/CombatHudVisibilityController.cs
+++ b/Assets/Aaron/Scripts/CombatHudVisibilityController.cs
@@ -1,0 +1,72 @@
+#nullable enable
+
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Hides combat HUD elements outside the Arena and listens to <see cref="BoolEventChannelSO"/>
+/// broadcasts from MapSceneController, NodeStarter, and DefeatStateController.
+/// </summary>
+public class CombatHudVisibilityController : MonoBehaviour
+{
+    private static readonly string[] HudElementNames =
+    {
+        "UltUI",
+        "TotalPointsText",
+        "WaveBanner",
+        "MinimapRoot",
+        "CombatHUDRoot",
+        "PlayerHealthBarRoot",
+    };
+
+    [SerializeField] private BoolEventChannelSO? visibilityChannel;
+
+    private readonly List<GameObject> _hudElements = new List<GameObject>();
+
+    private void Awake()
+    {
+        CacheHudElements();
+        ApplyVisibility(false);
+
+        if (visibilityChannel == null)
+        {
+            Debug.LogError("CombatHudVisibilityController: visibilityChannel is null");
+            return;
+        }
+
+        visibilityChannel.OnDataChanged += ApplyVisibility;
+    }
+
+    private void OnDestroy()
+    {
+        if (visibilityChannel != null)
+        {
+            visibilityChannel.OnDataChanged -= ApplyVisibility;
+        }
+    }
+
+    private void CacheHudElements()
+    {
+        _hudElements.Clear();
+
+        foreach (string elementName in HudElementNames)
+        {
+            Transform? child = transform.Find(elementName);
+            if (child != null)
+            {
+                _hudElements.Add(child.gameObject);
+            }
+        }
+    }
+
+    private void ApplyVisibility(bool isVisible)
+    {
+        foreach (GameObject element in _hudElements)
+        {
+            if (element != null)
+            {
+                element.SetActive(isVisible);
+            }
+        }
+    }
+}

--- a/Assets/Aaron/Scripts/CombatHudVisibilityController.cs.meta
+++ b/Assets/Aaron/Scripts/CombatHudVisibilityController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7c3e1f94b2d4a6e9f0d8c5b3a1e7f42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Aaron/Scripts/GameInitializer.cs
+++ b/Assets/Aaron/Scripts/GameInitializer.cs
@@ -16,6 +16,7 @@ public class GameInitializer : MonoBehaviour
 
     [Header("Loading")]
     [SerializeField] private BoolEventChannelSO? toggleLoadingScreenChannel;
+    [SerializeField] private BoolEventChannelSO? combatHudVisibilityChannel;
 
     [SerializeField] private List<InitializeableGameComponent> gameComponents = new List<InitializeableGameComponent>();
     [SerializeField] private List<InitializeableUnrestrictedGameComponent> unrestrictedGameComponents = new List<InitializeableUnrestrictedGameComponent>();
@@ -40,6 +41,9 @@ public class GameInitializer : MonoBehaviour
             yield break;
         }
 
+        toggleLoadingScreenChannel?.RaiseDataChanged(true);
+        combatHudVisibilityChannel?.RaiseDataChanged(false);
+
         if (playerBlobLoader.TryLoad(out var playerBlob) == false)
         {
             Debug.LogWarning("Player blob could not be loaded at this time. Using empty player blob.");
@@ -56,8 +60,6 @@ public class GameInitializer : MonoBehaviour
 
         foreach (var standaloneManager in standaloneManagers)
             standaloneManager.InitializeOnGameStart_Dangerous(playerBlob);
-
-        toggleLoadingScreenChannel?.RaiseDataChanged(true);
 
         yield return null;
 

--- a/Assets/Aaron/Scripts/LoadingSceneAnimator.cs
+++ b/Assets/Aaron/Scripts/LoadingSceneAnimator.cs
@@ -20,10 +20,10 @@ public class LoadingScreenAnimator : MonoBehaviour
             return;
         }
         
-        // aisara => Starting state is fully transparent and non-interactable (don't want to have to send an initialization signal to get it in this state)
-        canvasGroup.alpha = 0f;
-        canvasGroup.interactable = false;
-        canvasGroup.blocksRaycasts = false;
+        // aisara => Start opaque so boot shows black immediately, even before the first channel event arrives.
+        canvasGroup.alpha = 1f;
+        canvasGroup.interactable = true;
+        canvasGroup.blocksRaycasts = true;
     }
 
     public void FadeInLoadingScreen()

--- a/Assets/Scenes/Main/BootUp.unity
+++ b/Assets/Scenes/Main/BootUp.unity
@@ -250,7 +250,7 @@ Camera:
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_BackGroundColor: {r: 0, g: 0, b: 0, a: 0}
   m_projectionMatrixMode: 1
   m_GateFitMode: 2
   m_FOVAxisMode: 0
@@ -363,6 +363,7 @@ MonoBehaviour:
     sceneName: TitleScene
   vfxPrewarmer: {fileID: 9100000000000000006}
   toggleLoadingScreenChannel: {fileID: 11400000, guid: b30a0b4446b08487b827673eaf8987f7, type: 2}
+  combatHudVisibilityChannel: {fileID: 11400000, guid: 2ace426d79c4741a3bc741a39cb27a3d, type: 2}
   gameComponents:
   - {fileID: 1874817347}
   - {fileID: 873413179}

--- a/Assets/Scenes/Main/CombatHUD.unity
+++ b/Assets/Scenes/Main/CombatHUD.unity
@@ -790,6 +790,7 @@ GameObject:
   - component: {fileID: 376754622}
   - component: {fileID: 376754621}
   - component: {fileID: 376754620}
+  - component: {fileID: 376754624}
   m_Layer: 5
   m_Name: Canvas
   m_TagString: Untagged
@@ -860,6 +861,19 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &376754624
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 376754619}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a7c3e1f94b2d4a6e9f0d8c5b3a1e7f42, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Main::CombatHudVisibilityController
+  visibilityChannel: {fileID: 11400000, guid: 2ace426d79c4741a3bc741a39cb27a3d, type: 2}
 --- !u!224 &376754623
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/DefeatStateController.cs
+++ b/Assets/Scripts/UI/DefeatStateController.cs
@@ -34,10 +34,11 @@ public class DefeatStateController : MonoBehaviour
     [Header("Timing")]
     [SerializeField] private float fadeInDuration = DefaultFadeInSeconds;
     [SerializeField] private float holdDuration = DefaultHoldSeconds;
-    [SerializeField] private float skipHintDelay = 1f;
+    [SerializeField] private float skipDelayBeforeAllowed = 1f;
 
     private Coroutine? _sequenceRoutine;
     private bool _sequenceActive;
+    private float _skipEligibleAt;
 
     private void Awake()
     {
@@ -131,6 +132,12 @@ public class DefeatStateController : MonoBehaviour
         combatHudVisibilityChannel?.RaiseDataChanged(false);
         AudioSystem.FadeLoopVolume(AudioSystem.Sound.BGM, BgmDuckVolume, BgmDuckDuration);
 
+        _skipEligibleAt = Time.unscaledTime + skipDelayBeforeAllowed;
+        if (skipButton != null)
+        {
+            skipButton.interactable = false;
+        }
+
         _sequenceActive = true;
         _sequenceRoutine = StartCoroutine(SequenceRoutine());
     }
@@ -146,9 +153,19 @@ public class DefeatStateController : MonoBehaviour
             overlayGroup.alpha = 1f;
         }
 
-        if (skipHintText != null && skipHintDelay > 0f)
+        float waitUntilSkipAllowed = _skipEligibleAt - Time.unscaledTime;
+        if (waitUntilSkipAllowed > 0f)
         {
-            yield return new WaitForSecondsRealtime(skipHintDelay);
+            yield return new WaitForSecondsRealtime(waitUntilSkipAllowed);
+        }
+
+        if (skipButton != null)
+        {
+            skipButton.interactable = true;
+        }
+
+        if (skipHintText != null)
+        {
             skipHintText.gameObject.SetActive(true);
         }
 
@@ -162,7 +179,7 @@ public class DefeatStateController : MonoBehaviour
 
     private void OnSkipPressed()
     {
-        if (!_sequenceActive)
+        if (!_sequenceActive || Time.unscaledTime < _skipEligibleAt)
         {
             return;
         }
@@ -218,6 +235,11 @@ public class DefeatStateController : MonoBehaviour
         if (skipHintText != null)
         {
             skipHintText.gameObject.SetActive(false);
+        }
+
+        if (skipButton != null)
+        {
+            skipButton.interactable = false;
         }
     }
 


### PR DESCRIPTION
Show a black loading overlay from boot start, hide combat HUD until arena, and block defeat overlay skip for a configurable minimum delay.