### PR TITLE
Fix sword lodging and recall clip-through on baked arena walls.

### DIFF
--- a/Assets/Scripts/LevelGeneration/Editor/RoomBaker.cs
+++ b/Assets/Scripts/LevelGeneration/Editor/RoomBaker.cs
@@ -270,6 +270,17 @@ public static class RoomBaker
             var tmGO = new GameObject("WallTilemap");
             tmGO.transform.SetParent(gridGO.transform);
             tmGO.transform.localPosition = Vector3.zero;
+            // aisara => Walls must be on Arena so SwordProjectile.terrainLayers can lodge on hit
+            // and IgnoreLayerCollision can let recalls clip through (same contract as hand-built arenas).
+            int arenaLayer = LayerMask.NameToLayer("Arena");
+            if (arenaLayer < 0)
+            {
+                Debug.LogError("RoomBaker: 'Arena' physics layer is missing; walls will not interact with the sword correctly.");
+            }
+            else
+            {
+                tmGO.layer = arenaLayer;
+            }
             Tilemap tilemap = tmGO.AddComponent<Tilemap>();
             tmGO.AddComponent<TilemapRenderer>();
             tmGO.AddComponent<TilemapCollider2D>();

--- a/Assets/Visuals/Prefabs/BakedRooms/Arena_Center.prefab
+++ b/Assets/Visuals/Prefabs/BakedRooms/Arena_Center.prefab
@@ -56,7 +56,7 @@ GameObject:
   - component: {fileID: 4463886721149671827}
   - component: {fileID: 8546413877728920240}
   - component: {fileID: 4544836999558528603}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: WallTilemap
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Visuals/Prefabs/BakedRooms/Arena_Circle.prefab
+++ b/Assets/Visuals/Prefabs/BakedRooms/Arena_Circle.prefab
@@ -895,7 +895,7 @@ GameObject:
   - component: {fileID: 1859516342827825061}
   - component: {fileID: 3266737467128378431}
   - component: {fileID: 8440414124237892339}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: WallTilemap
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Visuals/Prefabs/BakedRooms/Arena_Cross.prefab
+++ b/Assets/Visuals/Prefabs/BakedRooms/Arena_Cross.prefab
@@ -454,7 +454,7 @@ GameObject:
   - component: {fileID: 5087888166662995524}
   - component: {fileID: 8828112081569032417}
   - component: {fileID: 3150303889947579871}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: WallTilemap
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Visuals/Prefabs/BakedRooms/Arena_Square.prefab
+++ b/Assets/Visuals/Prefabs/BakedRooms/Arena_Square.prefab
@@ -56,7 +56,7 @@ GameObject:
   - component: {fileID: 6271797216754366385}
   - component: {fileID: 5292345726252979359}
   - component: {fileID: 8790716016370013653}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: WallTilemap
   m_TagString: Untagged
   m_Icon: {fileID: 0}


### PR DESCRIPTION
Room Painter baked WallTilemaps onto Default instead of Arena, so SwordProjectile's terrain mask stopped matching walls for lodge triggers and recall collision ignores.