### PR TITLE
Parent catch and cleave VFX on the player

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -400,7 +400,7 @@ public class PlayerController : PlayerGameplayPawn
             return;
         }
 
-        GameObject fx = Instantiate(catchExplosionFX, transform.position, Quaternion.identity);
+        GameObject fx = Instantiate(catchExplosionFX, transform.position, Quaternion.identity, transform);
         CatchExplosionFX? explosion = fx.GetComponent<CatchExplosionFX>();
         if (explosion != null)
         {

--- a/Assets/Scripts/Weapon Implementations/FireWeapon.cs
+++ b/Assets/Scripts/Weapon Implementations/FireWeapon.cs
@@ -237,7 +237,7 @@ public class FireWeapon : MonoBehaviour, IElementalWeapon, IMeleeChargeProvider
             yield break;
         }
 
-        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity);
+        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity, player);
         effect.transform.up = player.up;
         IAttackAnimator attackAnimator = effect.GetComponent<IAttackAnimator>();
         attackAnimator.PlayAnimation();

--- a/Assets/Scripts/Weapon Implementations/IceWeapon.cs
+++ b/Assets/Scripts/Weapon Implementations/IceWeapon.cs
@@ -160,7 +160,7 @@ public class IceWeapon : MonoBehaviour, IElementalWeapon
             yield break;
         }
 
-        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity);
+        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity, player);
         effect.transform.up = player.up;
         IAttackAnimator attackAnimator = effect.GetComponent<IAttackAnimator>();
         attackAnimator.PlayAnimation();

--- a/Assets/Scripts/Weapon Implementations/LightningWeapon.cs
+++ b/Assets/Scripts/Weapon Implementations/LightningWeapon.cs
@@ -210,7 +210,7 @@ public class LightningWeapon : MonoBehaviour, IElementalWeapon
             yield break;
         }
 
-        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity);
+        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity, player);
         effect.transform.up = player.up;
         IAttackAnimator attackAnimator = effect.GetComponent<IAttackAnimator>();
         attackAnimator.PlayAnimation();

--- a/Assets/Scripts/Weapon Implementations/PhysicalWeapon.cs
+++ b/Assets/Scripts/Weapon Implementations/PhysicalWeapon.cs
@@ -122,7 +122,7 @@ public class PhysicalWeapon : MonoBehaviour, IElementalWeapon
             yield break;
         }
 
-        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity);
+        GameObject effect = PrefabPool.Instance!.Spawn(cleaveEffectObject, player.position, Quaternion.identity, player);
         effect.transform.up = player.up;
         IAttackAnimator attackAnimator = effect.GetComponent<IAttackAnimator>();
         attackAnimator.PlayAnimation();


### PR DESCRIPTION
## Summary
- Parent elemental cleave VFX (basic, fire, ice, lightning) to the player transform when the sword is caught, so the AoE ring follows the player instead of staying at the catch point.
- Parent CatchExplosionFX on the player transform when a recall catch succeeds.