### PR TITLE
Tint attack joystick knob from the active element.

### DIFF
--- a/Assets/Aaron/Prefabs/Attack Control Region (Player Centric).prefab
+++ b/Assets/Aaron/Prefabs/Attack Control Region (Player Centric).prefab
@@ -136,7 +136,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.0047169924, b: 0.0047169924, a: 1}
+  m_Color: {r: 0.55, g: 0.55, b: 0.55, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
@@ -790,5 +790,7 @@ MonoBehaviour:
   iconImage: {fileID: 8348080972069032173}
   attackIconSprite: {fileID: -4595611934606938456, guid: b547d469b6437483fa4d1169c32c0419, type: 3}
   dashIconSprite: {fileID: 21300000, guid: 269d0adec98441349b057e8673021bc0, type: 3}
+  knobImage: {fileID: 6538003213827653658}
   imbueBorder: {fileID: 1995915782623287117}
   inactiveBorderColor: {r: 1, g: 1, b: 1, a: 0}
+  inactiveKnobColor: {r: 0.55, g: 0.55, b: 0.55, a: 1}

--- a/Assets/Aaron/Prefabs/Attack Control Region.prefab
+++ b/Assets/Aaron/Prefabs/Attack Control Region.prefab
@@ -436,8 +436,10 @@ MonoBehaviour:
   iconImage: {fileID: 2290692626614769150}
   attackIconSprite: {fileID: -4595611934606938456, guid: b547d469b6437483fa4d1169c32c0419, type: 3}
   dashIconSprite: {fileID: 21300000, guid: 269d0adec98441349b057e8673021bc0, type: 3}
+  knobImage: {fileID: 9219878326355407520}
   imbueBorder: {fileID: 8719197531079096484}
   inactiveBorderColor: {r: 1, g: 1, b: 1, a: 0}
+  inactiveKnobColor: {r: 0.55, g: 0.55, b: 0.55, a: 1}
 --- !u!1 &7450482144262450167
 GameObject:
   m_ObjectHideFlags: 0
@@ -498,7 +500,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.0047169924, b: 0.0047169924, a: 1}
+  m_Color: {r: 0.55, g: 0.55, b: 0.55, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Aaron/Scripts/Input/AttackJoystickImbueIndicator.cs
+++ b/Assets/Aaron/Scripts/Input/AttackJoystickImbueIndicator.cs
@@ -4,26 +4,43 @@ using UnityEngine;
 using UnityEngine.UI;
 
 /// <summary>
-/// Drives the attack joystick's icon (sword vs. dash), imbue tint, and radial imbue-duration
-/// border. Lives alongside ChargeAttackJoystickIndicator on the "Joystick" node.
+/// Drives the attack joystick's icon (sword vs. dash), range-knob tint, imbue tint, and
+/// radial imbue-duration border. Lives alongside ChargeAttackJoystickIndicator on the
+/// "Joystick" node.
 /// </summary>
 public class AttackJoystickImbueIndicator : MonoBehaviour
 {
     [SerializeField] private Image? iconImage;
     [SerializeField] private Sprite? attackIconSprite;
     [SerializeField] private Sprite? dashIconSprite;
+    [SerializeField] private Image? knobImage;
     [SerializeField] private RadialBorderTimer? imbueBorder;
     [SerializeField] private Color inactiveBorderColor = new(1f, 1f, 1f, 0f);
+    [SerializeField] private Color inactiveKnobColor = new(0.55f, 0.55f, 0.55f, 1f);
 
     private Element _activeElement = Element.Physical;
     private bool _subscribedToGameManager;
+    private float _knobAlpha = 1f;
+
+    private void Awake()
+    {
+        if (knobImage != null)
+        {
+            _knobAlpha = knobImage.color.a;
+        }
+    }
 
     private void OnEnable()
     {
         ElementManager.OnActiveElementChanged += HandleActiveElementChanged;
+        if (ElementManager.Instance != null)
+        {
+            _activeElement = ElementManager.Instance.ActiveElement;
+        }
+
         TrySubscribeToGameManager();
         UpdateIcon();
-        RefreshBorderColor();
+        RefreshColors();
     }
 
     private void OnDisable()
@@ -77,7 +94,7 @@ public class AttackJoystickImbueIndicator : MonoBehaviour
     private void HandleActiveElementChanged(Element element)
     {
         _activeElement = element;
-        RefreshBorderColor();
+        RefreshColors();
 
         if (element == Element.Physical && imbueBorder != null)
         {
@@ -91,12 +108,22 @@ public class AttackJoystickImbueIndicator : MonoBehaviour
         imbueBorder.Progress = duration > 0f ? remaining / duration : 0f;
     }
 
-    private void RefreshBorderColor()
+    private void RefreshColors()
     {
-        if (imbueBorder == null) return;
+        if (imbueBorder != null)
+        {
+            imbueBorder.color = _activeElement == Element.Physical
+                ? inactiveBorderColor
+                : ElementVisualUtility.GetAccentColor(_activeElement);
+        }
 
-        imbueBorder.color = _activeElement == Element.Physical
-            ? inactiveBorderColor
-            : ElementVisualUtility.GetAccentColor(_activeElement);
+        if (knobImage != null)
+        {
+            Color tint = _activeElement == Element.Physical
+                ? inactiveKnobColor
+                : ElementVisualUtility.GetAccentColor(_activeElement);
+            tint.a = _knobAlpha;
+            knobImage.color = tint;
+        }
     }
 }


### PR DESCRIPTION
Default the range ring to gray when Physical so it matches imbue-border accents instead of a hard-coded red.