### PR TITLE
Fix attack joystick dash-mode visuals and suppress imbue while sword is out

### DIFF
--- a/Assets/Aaron/Prefabs/Attack Control Region (Player Centric).prefab
+++ b/Assets/Aaron/Prefabs/Attack Control Region (Player Centric).prefab
@@ -498,7 +498,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Sprite: {fileID: -7559798307494053763, guid: 929ecacc45d6347abba712b69edd3be2, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -788,9 +788,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Main::AttackJoystickImbueIndicator
   iconImage: {fileID: 8348080972069032173}
-  attackIconSprite: {fileID: -4595611934606938456, guid: b547d469b6437483fa4d1169c32c0419, type: 3}
+  attackIconSprite: {fileID: -7559798307494053763, guid: 929ecacc45d6347abba712b69edd3be2, type: 3}
   dashIconSprite: {fileID: 21300000, guid: 269d0adec98441349b057e8673021bc0, type: 3}
+  knobBackingSprite: {fileID: -1710961190818768919, guid: 4e7829d048ea6436a98267d8422f6bf0, type: 3}
   knobImage: {fileID: 6538003213827653658}
   imbueBorder: {fileID: 1995915782623287117}
   inactiveBorderColor: {r: 1, g: 1, b: 1, a: 0}
   inactiveKnobColor: {r: 0.55, g: 0.55, b: 0.55, a: 1}
+  dashIconScale: 0.55

--- a/Assets/Aaron/Prefabs/Attack Control Region.prefab
+++ b/Assets/Aaron/Prefabs/Attack Control Region.prefab
@@ -192,7 +192,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Sprite: {fileID: -7559798307494053763, guid: 929ecacc45d6347abba712b69edd3be2, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -434,12 +434,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Main::AttackJoystickImbueIndicator
   iconImage: {fileID: 2290692626614769150}
-  attackIconSprite: {fileID: -4595611934606938456, guid: b547d469b6437483fa4d1169c32c0419, type: 3}
+  attackIconSprite: {fileID: -7559798307494053763, guid: 929ecacc45d6347abba712b69edd3be2, type: 3}
   dashIconSprite: {fileID: 21300000, guid: 269d0adec98441349b057e8673021bc0, type: 3}
+  knobBackingSprite: {fileID: -1710961190818768919, guid: 4e7829d048ea6436a98267d8422f6bf0, type: 3}
   knobImage: {fileID: 9219878326355407520}
   imbueBorder: {fileID: 8719197531079096484}
   inactiveBorderColor: {r: 1, g: 1, b: 1, a: 0}
   inactiveKnobColor: {r: 0.55, g: 0.55, b: 0.55, a: 1}
+  dashIconScale: 0.55
 --- !u!1 &7450482144262450167
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Aaron/Scripts/Input/AttackJoystickImbueIndicator.cs
+++ b/Assets/Aaron/Scripts/Input/AttackJoystickImbueIndicator.cs
@@ -4,29 +4,46 @@ using UnityEngine;
 using UnityEngine.UI;
 
 /// <summary>
-/// Drives the attack joystick's icon (sword vs. dash), range-knob tint, imbue tint, and
-/// radial imbue-duration border. Lives alongside ChargeAttackJoystickIndicator on the
-/// "Joystick" node.
+/// Attack mode: Knob shows shadedDark49 (pad + glyph); range ring tints from the active element.
+/// Dash mode: Knob keeps a plain dark pad with DashIcon on top; imbue border and elemental
+/// range-ring tint are suppressed (Physical / gray) until the sword is caught.
 /// </summary>
 public class AttackJoystickImbueIndicator : MonoBehaviour
 {
     [SerializeField] private Image? iconImage;
     [SerializeField] private Sprite? attackIconSprite;
     [SerializeField] private Sprite? dashIconSprite;
+    [SerializeField] private Sprite? knobBackingSprite;
     [SerializeField] private Image? knobImage;
     [SerializeField] private RadialBorderTimer? imbueBorder;
     [SerializeField] private Color inactiveBorderColor = new(1f, 1f, 1f, 0f);
     [SerializeField] private Color inactiveKnobColor = new(0.55f, 0.55f, 0.55f, 1f);
+    [SerializeField] private float dashIconScale = 0.55f;
 
     private Element _activeElement = Element.Physical;
     private bool _subscribedToGameManager;
+    private Image? _modeKnobImage;
+    private RectTransform? _dashOverlayRect;
+    private bool _dashSuppressingImbue;
+    private float _storedImbueProgress;
     private float _knobAlpha = 1f;
 
     private void Awake()
     {
+        Transform? knob = transform.Find("Knob");
+        _modeKnobImage = knob != null ? knob.GetComponent<Image>() : null;
+
         if (knobImage != null)
         {
             _knobAlpha = knobImage.color.a;
+        }
+
+        if (iconImage != null)
+        {
+            _dashOverlayRect = iconImage.rectTransform;
+            iconImage.enabled = false;
+            iconImage.raycastTarget = false;
+            iconImage.preserveAspect = true;
         }
     }
 
@@ -39,7 +56,7 @@ public class AttackJoystickImbueIndicator : MonoBehaviour
         }
 
         TrySubscribeToGameManager();
-        UpdateIcon();
+        UpdateModeVisuals();
         RefreshColors();
     }
 
@@ -60,7 +77,7 @@ public class AttackJoystickImbueIndicator : MonoBehaviour
             TrySubscribeToGameManager();
         }
 
-        UpdateIcon();
+        UpdateModeVisuals();
     }
 
     private void TrySubscribeToGameManager()
@@ -71,9 +88,9 @@ public class AttackJoystickImbueIndicator : MonoBehaviour
         _subscribedToGameManager = true;
     }
 
-    private void UpdateIcon()
+    private void UpdateModeVisuals()
     {
-        if (iconImage == null) return;
+        if (_modeKnobImage == null) return;
 
         // GameManager.playerController is only derived once in Awake and goes stale once
         // PlayerGameplayManager reassigns GameManager.player at runtime, so resolve live instead
@@ -83,43 +100,141 @@ public class AttackJoystickImbueIndicator : MonoBehaviour
             : null;
         bool swordOut = player != null && player.IsSwordOut;
 
-        Sprite? desired = swordOut ? dashIconSprite : attackIconSprite;
-        if (iconImage.sprite != desired)
+        if (swordOut)
         {
-            iconImage.sprite = desired;
+            ApplyDashMode();
         }
-        iconImage.enabled = desired != null;
+        else
+        {
+            ApplyAttackMode();
+        }
+    }
+
+    private void ApplyAttackMode()
+    {
+        Sprite? attackSprite = attackIconSprite;
+        if (attackSprite != null && _modeKnobImage!.sprite != attackSprite)
+        {
+            _modeKnobImage.sprite = attackSprite;
+        }
+        _modeKnobImage!.enabled = attackSprite != null;
+
+        if (iconImage != null)
+        {
+            iconImage.enabled = false;
+        }
+
+        if (_dashSuppressingImbue)
+        {
+            _dashSuppressingImbue = false;
+            RefreshColors();
+        }
+    }
+
+    private void ApplyDashMode()
+    {
+        // Keep the same circular pad family under DashIcon.
+        Sprite? backing = knobBackingSprite != null ? knobBackingSprite : attackIconSprite;
+        if (backing != null && _modeKnobImage!.sprite != backing)
+        {
+            _modeKnobImage.sprite = backing;
+        }
+        _modeKnobImage!.enabled = backing != null;
+
+        if (iconImage != null && dashIconSprite != null)
+        {
+            EnsureDashOverlayOnKnob();
+            if (iconImage.sprite != dashIconSprite)
+            {
+                iconImage.sprite = dashIconSprite;
+            }
+            iconImage.enabled = true;
+        }
+
+        if (!_dashSuppressingImbue)
+        {
+            _dashSuppressingImbue = true;
+            if (imbueBorder != null)
+            {
+                _storedImbueProgress = imbueBorder.Progress;
+            }
+            RefreshColors();
+        }
+    }
+
+    private void EnsureDashOverlayOnKnob()
+    {
+        if (iconImage == null || _modeKnobImage == null || _dashOverlayRect == null) return;
+
+        if (_dashOverlayRect.parent != _modeKnobImage.transform)
+        {
+            _dashOverlayRect.SetParent(_modeKnobImage.transform, worldPositionStays: false);
+        }
+
+        _dashOverlayRect.SetAsLastSibling();
+        _dashOverlayRect.anchorMin = new Vector2(0.5f, 0.5f);
+        _dashOverlayRect.anchorMax = new Vector2(0.5f, 0.5f);
+        _dashOverlayRect.pivot = new Vector2(0.5f, 0.5f);
+        _dashOverlayRect.anchoredPosition = Vector2.zero;
+        _dashOverlayRect.localRotation = Quaternion.identity;
+        _dashOverlayRect.localScale = Vector3.one;
+
+        Vector2 knobSize = _modeKnobImage.rectTransform.sizeDelta;
+        _dashOverlayRect.sizeDelta = knobSize * dashIconScale;
     }
 
     private void HandleActiveElementChanged(Element element)
     {
         _activeElement = element;
-        RefreshColors();
 
-        if (element == Element.Physical && imbueBorder != null)
+        if (element == Element.Physical)
         {
-            imbueBorder.Progress = 0f;
+            _storedImbueProgress = 0f;
         }
+
+        RefreshColors();
     }
 
     private void HandleEmpowermentTimerChanged(float remaining, float duration)
     {
-        if (imbueBorder == null) return;
-        imbueBorder.Progress = duration > 0f ? remaining / duration : 0f;
+        float progress = duration > 0f ? remaining / duration : 0f;
+        _storedImbueProgress = progress;
+
+        if (_dashSuppressingImbue || imbueBorder == null)
+        {
+            // Keep tracking duration while sword is out; only the visible border is suppressed.
+            if (_dashSuppressingImbue && imbueBorder != null)
+            {
+                imbueBorder.Progress = 0f;
+            }
+            return;
+        }
+
+        imbueBorder.Progress = progress;
     }
 
     private void RefreshColors()
     {
+        bool useInactive = _dashSuppressingImbue || _activeElement == Element.Physical;
+
         if (imbueBorder != null)
         {
-            imbueBorder.color = _activeElement == Element.Physical
-                ? inactiveBorderColor
-                : ElementVisualUtility.GetAccentColor(_activeElement);
+            if (useInactive)
+            {
+                imbueBorder.color = inactiveBorderColor;
+                imbueBorder.Progress = 0f;
+            }
+            else
+            {
+                imbueBorder.color = ElementVisualUtility.GetAccentColor(_activeElement);
+                imbueBorder.Progress = _storedImbueProgress;
+            }
         }
 
+        // knobImage is the Range Indicator ring (element accent / gray when Physical or dash).
         if (knobImage != null)
         {
-            Color tint = _activeElement == Element.Physical
+            Color tint = useInactive
                 ? inactiveKnobColor
                 : ElementVisualUtility.GetAccentColor(_activeElement);
             tint.a = _knobAlpha;


### PR DESCRIPTION
This is to really clean up the visuals for the dash