### PR TITLE
Add Android APK build step to CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,3 +86,31 @@ jobs:
         uses: geekyeggo/delete-artifact@v6
         with:
           name: build-iOS
+
+  buildForAndroidPlatform:
+    name: Build for Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/cache@v5
+        with:
+          path: Library
+          key: Library-Android
+
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@main
+
+      - uses: game-ci/unity-builder@v5
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          targetPlatform: Android
+          androidExportType: androidPackage
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: SwordGear.apk
+          path: build/Android


### PR DESCRIPTION
## Summary
- Adds a `buildForAndroidPlatform` job to the main CI/CD workflow that builds an Android APK with `game-ci/unity-builder@v5`
- Includes Library caching and a free-disk-space step (GameCI recommendation for Android on ubuntu-latest)
- Uploads the APK as a `SwordGear.apk` artifact; signing and Play Store upload are left for a follow-up

## Test plan
- [ ] Trigger the workflow via `workflow_dispatch` (or push after merge)
- [ ] Confirm `Build for Android` job completes successfully
- [ ] Download the `SwordGear.apk` artifact and verify it contains an `.apk`
- [ ] Confirm existing iOS jobs still run in parallel and are unaffected


Made with [Cursor](https://cursor.com)