### PR TITLE
Auto-declare iOS export compliance for TestFlight

### DIFF
--- a/Assets/Aaron/Editor/iOSBuildPostProcessor.cs
+++ b/Assets/Aaron/Editor/iOSBuildPostProcessor.cs
@@ -1,0 +1,28 @@
+#nullable enable
+
+#if UNITY_IOS
+
+using System.IO;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+
+public static class iOSBuildPostProcessor
+{
+    [PostProcessBuild]
+    public static void OnPostprocessBuild(BuildTarget target, string pathToBuiltProject)
+    {
+        if (target != BuildTarget.iOS)
+        {
+            return;
+        }
+
+        string plistPath = Path.Combine(pathToBuiltProject, "Info.plist");
+        var plist = new PlistDocument();
+        plist.ReadFromFile(plistPath);
+        plist.root.SetBoolean("ITSAppUsesNonExemptEncryption", false);
+        plist.WriteToFile(plistPath);
+    }
+}
+
+#endif

--- a/Assets/Aaron/Editor/iOSBuildPostProcessor.cs
+++ b/Assets/Aaron/Editor/iOSBuildPostProcessor.cs
@@ -1,6 +1,10 @@
 #nullable enable
 
-#if UNITY_IOS
+// aisara => This project has no dedicated Editor asmdef; Assets/Main.asmdef compiles
+// Assets/Aaron/Editor/ into the shared runtime assembly. Guarding on UNITY_EDITOR (not
+// just UNITY_IOS) keeps this out of the player build, where UnityEditor and the Xcode
+// plist API are not referenced. The BuildTarget check below scopes it to iOS builds.
+#if UNITY_EDITOR && UNITY_IOS
 
 using System.IO;
 using UnityEditor;

--- a/Assets/Aaron/Editor/iOSBuildPostProcessor.cs.meta
+++ b/Assets/Aaron/Editor/iOSBuildPostProcessor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c7edc0f2325c43e6b55bede07d6f80c7
+timeCreated: 1784414219


### PR DESCRIPTION
## Summary
- Add an iOS post-process build script that writes `ITSAppUsesNonExemptEncryption=false` into the generated `Info.plist`
- Avoids manually answering Apple's export-compliance / encryption questionnaire on every TestFlight upload

## Test plan
- [ ] Build for iOS from Unity and confirm the generated Xcode `Info.plist` contains `ITSAppUsesNonExemptEncryption` set to `false`
- [ ] Upload the IPA / build to TestFlight and confirm the encryption compliance form is no longer required
- [ ] Confirm Unity console has no compile errors after importing the new editor script


Made with [Cursor](https://cursor.com)